### PR TITLE
Remove logic responsible to manually set cart URL

### DIFF
--- a/components/composite/MicrostoreContainer/index.tsx
+++ b/components/composite/MicrostoreContainer/index.tsx
@@ -27,21 +27,6 @@ const MicrostoreContainer: React.FC<Props> = ({
   const { cart } = useDataFromUrl()
   const returnUrl = window.location.href
 
-  // we set cart url as internal state. In this way, once we get the order id
-  // the <OrderContainer> will receive the proper url and will update the order
-  const [cartUrl, setCartUrl] = useState<string>()
-  const updateCartUrl = (orderId?: string) => {
-    if (!cartUrl && orderId && cart) {
-      setCartUrl(
-        makeHostedAppUrl({
-          basePath: "cart",
-          orderId,
-          accessToken: settings.accessToken,
-        })
-      )
-    }
-  }
-
   return (
     <CommerceLayer
       accessToken={settings.accessToken}
@@ -52,11 +37,7 @@ const MicrostoreContainer: React.FC<Props> = ({
         <OrderContainer
           attributes={{
             coupon_code: couponCode,
-            cart_url: cartUrl,
             return_url: returnUrl,
-          }}
-          fetchOrder={(order) => {
-            updateCartUrl(order.id)
           }}
         >
           <Base>

--- a/components/data/BuyAllProvider/index.tsx
+++ b/components/data/BuyAllProvider/index.tsx
@@ -60,7 +60,6 @@ export const BuyAllProvider: FC<BuyAllProviderProps> = ({
         accessToken: settings.accessToken,
         domain: settings.domain,
         slug: settings.slug,
-        setCartUrl: Boolean(cart),
       })
 
       if (!order) {
@@ -71,13 +70,11 @@ export const BuyAllProvider: FC<BuyAllProviderProps> = ({
       }
 
       if (cart) {
-        window.location.href =
-          order.cart_url ||
-          makeHostedAppUrl({
-            basePath: "cart",
-            orderId: order.id,
-            accessToken: settings.accessToken,
-          })
+        window.location.href = makeHostedAppUrl({
+          basePath: "cart",
+          orderId: order.id,
+          accessToken: settings.accessToken,
+        })
         return
       }
 

--- a/components/utils/buyAllSkus.ts
+++ b/components/utils/buyAllSkus.ts
@@ -11,13 +11,11 @@ export const buyAllSkus = async ({
   accessToken,
   slug,
   domain,
-  setCartUrl,
 }: {
   skus: { skuCode: string; quantity: number }[]
   accessToken: string
   slug: string
   domain: string
-  setCartUrl?: boolean
 }) => {
   const client = CommerceLayer({
     organization: slug,
@@ -34,9 +32,6 @@ export const buyAllSkus = async ({
     client,
     orderId,
     autorefresh: true,
-    cartUrl: setCartUrl
-      ? makeHostedAppUrl({ basePath: "cart", orderId, accessToken })
-      : undefined,
     returnUrl: window.location.href,
   })
 

--- a/components/utils/updateOrderAttributes.ts
+++ b/components/utils/updateOrderAttributes.ts
@@ -4,19 +4,16 @@ export const updateOrderAttributes = async ({
   client,
   orderId,
   autorefresh,
-  cartUrl,
   returnUrl,
 }: {
   client: CommerceLayerClient
   orderId: string
   autorefresh: boolean
-  cartUrl?: string
   returnUrl?: string
 }) => {
   return await client.orders.update({
     id: orderId,
     autorefresh,
-    cart_url: cartUrl,
     return_url: returnUrl,
   })
 }


### PR DESCRIPTION
### What does this PR do?
Since hosted cart now always set a proper `cart_url` we don't need to keep this logic in microstore.
Microstore will be only responsible to link the hosted cart

