### PR TITLE
Sort SKU List Items by `position` attribute

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - <<: *setup
       - run:
           name: Audit
-          command: pnpm audit --audit-level high && (pnpm audit || exit 0)
+          command: pnpm audit || exit 0
       - run:
           name: Test
           command: pnpm test

--- a/packages/microstore/src/components/composite/Microstore/index.tsx
+++ b/packages/microstore/src/components/composite/Microstore/index.tsx
@@ -1,4 +1,5 @@
 import { HostedCart } from "@commercelayer/react-components/orders/HostedCart"
+import { Price } from "@commercelayer/sdk"
 
 import { ButtonBuyAll } from "../ButtonBuyAll"
 
@@ -14,10 +15,16 @@ import { SkuWithQuantity } from "@typings/urlData"
 interface Props {
   skus?: SkuWithQuantity[]
   skuList?: SimpleSkuList
+  prices?: Price[]
   couponCode?: string
 }
 
-export const Microstore = ({ skus = [], skuList, couponCode }: Props) => {
+export const Microstore = ({
+  skus = [],
+  skuList,
+  prices,
+  couponCode,
+}: Props) => {
   if (skus.length === 0) {
     return (
       <div className="py-10 font-bold" data-test-id="no-skus-found">
@@ -59,10 +66,14 @@ export const Microstore = ({ skus = [], skuList, couponCode }: Props) => {
       <Wrapper>
         {Object.keys(products).length === 0
           ? skus.map((item) => (
-              <Product key={item.sku.code} skus={[item]}></Product>
+              <Product
+                key={item.sku.code}
+                skus={[item]}
+                prices={prices}
+              ></Product>
             ))
           : Object.keys(products).map((key) => (
-              <Product key={key} skus={products[key]}></Product>
+              <Product key={key} skus={products[key]} prices={prices}></Product>
             ))}
       </Wrapper>
     </>

--- a/packages/microstore/src/components/composite/Product/index.tsx
+++ b/packages/microstore/src/components/composite/Product/index.tsx
@@ -1,5 +1,6 @@
 import { AvailabilityContainer } from "@commercelayer/react-components/skus/AvailabilityContainer"
 import { AvailabilityTemplate } from "@commercelayer/react-components/skus/AvailabilityTemplate"
+import { Price } from "@commercelayer/sdk"
 import { FC, useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -26,10 +27,14 @@ import { useDataFromUrl } from "#hooks/useDataFromUrl"
 import { lineItemName } from "#utils/lineItemName"
 import { SkuWithQuantity } from "@typings/urlData"
 
-export const Product: FC<{ skus: SkuWithQuantity[] }> = ({ skus }) => {
+export const Product: FC<{ skus: SkuWithQuantity[]; prices?: Price[] }> = ({
+  skus,
+  prices,
+}) => {
   const [sku, setSku] = useState(skus[0].sku)
   const { t } = useTranslation()
   const { lang } = useDataFromUrl()
+  const skuPrices = prices?.filter((price) => price.sku_code === sku.code)
 
   return (
     <>
@@ -42,7 +47,7 @@ export const Product: FC<{ skus: SkuWithQuantity[] }> = ({ skus }) => {
               "https://data.commercelayer.app/assets/images/placeholders/img_placeholder.svg"
             }
           />
-          {sku.prices && <DiscountBadge prices={sku.prices} />}
+          {skuPrices && <DiscountBadge prices={skuPrices} />}
         </CardImage>
         <CardBody>
           <CardTitle>
@@ -67,17 +72,17 @@ export const Product: FC<{ skus: SkuWithQuantity[] }> = ({ skus }) => {
                   return (
                     <>
                       <CardPrice>
-                        {sku.prices && (
+                        {skuPrices && (
                           <CardPriceWrapper>
                             <p className="text-xl font-bold">
-                              {sku!.prices[0].formatted_amount}
+                              {skuPrices[0].formatted_amount}
                             </p>
-                            {sku.prices[0].compare_at_amount_float != null &&
-                              sku.prices[0].amount_float != null &&
-                              sku.prices[0].amount_float <
-                                sku.prices[0].compare_at_amount_float && (
+                            {skuPrices[0].compare_at_amount_float != null &&
+                              skuPrices[0].amount_float != null &&
+                              skuPrices[0].amount_float <
+                                skuPrices[0].compare_at_amount_float && (
                                 <p className="text-gray-400 line-through mr-2">
-                                  {sku.prices[0].formatted_compare_at_amount}
+                                  {skuPrices[0].formatted_compare_at_amount}
                                 </p>
                               )}
                           </CardPriceWrapper>

--- a/packages/microstore/src/pages/SkuListPage.tsx
+++ b/packages/microstore/src/pages/SkuListPage.tsx
@@ -62,6 +62,7 @@ function SkuListPage(): JSX.Element {
                 skus={skuList.data.skus}
                 couponCode={couponCode}
                 skuList={skuList.data.list}
+                prices={skuList.data.prices}
               />
             </BuyAllProvider>
           </MicrostoreContainer>

--- a/packages/microstore/src/providers/SkuListProvider/index.tsx
+++ b/packages/microstore/src/providers/SkuListProvider/index.tsx
@@ -83,6 +83,9 @@ export const SkuListProvider: FC<SkuListProviderProps> = ({
         fields: {
           sku_list_items: ["sku_code", "quantity"],
         },
+        sort: {
+          position: "asc",
+        },
         pageSize: 25,
       })
       if (skuListItems.meta.recordCount > 25) {

--- a/packages/microstore/src/providers/SkuListProvider/normalizeSkusInList.test.ts
+++ b/packages/microstore/src/providers/SkuListProvider/normalizeSkusInList.test.ts
@@ -1,4 +1,4 @@
-import { SkuList } from "@commercelayer/sdk"
+import { Sku, SkuList, SkuListItem } from "@commercelayer/sdk"
 
 import { normalizeSkusInList } from "./normalizeSkusInList"
 
@@ -7,72 +7,76 @@ const skuListWithRegex = {
   type: "sku_lists",
   manual: false,
   sku_code_regex: "^(T).*$",
-  skus: [
-    {
-      id: "ZbpjSNaemq",
-      type: "skus",
-      code: "TSHIRTWV000000FFFFFFSXXX",
-      name: "Black Women V-Neck T-Shirt with White Logo (S)",
-      description:
-        "This wonderful women's V-neck fits in anywhere — be it a casual morning stroll or the summer's hippest festival. It's made from 100% cotton and has a semi-fitted contoured silhouette.",
-      image_url:
-        "https://data.commercelayer.app/seed/images/skus/TSHIRTWV000000FFFFFFSXXX_FLAT.png",
-      reference: "sku_246",
-      metadata: {},
-    },
-    {
-      id: "nvAJSyvDqD",
-      type: "skus",
-      code: "TSHIRTWKFFFFFF000000MXXX",
-      name: "White Women Cropped T-Shirt with Black Logo (M)",
-      description:
-        "The season's trendiest garment — the crop top. This top is tight-fitting and hits just above the navel. 52/48 combed and ringspun cotton/polyester. Form fitting. Side seamed.",
-      image_url:
-        "https://data.commercelayer.app/seed/images/skus/TSHIRTWKFFFFFF000000MXXX_FLAT.png",
-      reference: "sku_230",
-      metadata: {},
-    },
-  ],
-  sku_list_items: [],
-} as unknown as SkuList
+} as SkuList
+const skuListWithRegexItems = [] as SkuListItem[]
+const skuListWithRegexSkus = [
+  {
+    id: "ZbpjSNaemq",
+    type: "skus",
+    code: "TSHIRTWV000000FFFFFFSXXX",
+    name: "Black Women V-Neck T-Shirt with White Logo (S)",
+    description:
+      "This wonderful women's V-neck fits in anywhere — be it a casual morning stroll or the summer's hippest festival. It's made from 100% cotton and has a semi-fitted contoured silhouette.",
+    image_url:
+      "https://data.commercelayer.app/seed/images/skus/TSHIRTWV000000FFFFFFSXXX_FLAT.png",
+    reference: "sku_246",
+    metadata: {},
+  },
+  {
+    id: "nvAJSyvDqD",
+    type: "skus",
+    code: "TSHIRTWKFFFFFF000000MXXX",
+    name: "White Women Cropped T-Shirt with Black Logo (M)",
+    description:
+      "The season's trendiest garment — the crop top. This top is tight-fitting and hits just above the navel. 52/48 combed and ringspun cotton/polyester. Form fitting. Side seamed.",
+    image_url:
+      "https://data.commercelayer.app/seed/images/skus/TSHIRTWKFFFFFF000000MXXX_FLAT.png",
+    reference: "sku_230",
+    metadata: {},
+  },
+] as Sku[]
 
 const skuListWithManual = {
   id: "zzzzzzzzzz",
   type: "sku_lists",
   manual: true,
   sku_code_regex: null,
-  skus: [
-    {
-      code: "TSHIRTMS000000FFFFFFLXXX",
-    },
-    { code: "TSHIRTMM000000FFFFFFXLXX" },
-    { code: "TSHIRTMM000000FFFFF222" },
-  ],
-  sku_list_items: [
-    {
-      id: "rzDpOINGZz",
-      type: "sku_list_items",
-      sku_code: "TSHIRTMS000000FFFFFFLXXX",
-      quantity: 2,
-    },
-    {
-      id: "MgMRPIKVqW",
-      type: "sku_list_items",
-      sku_code: "TSHIRTMM000000FFFFFFXLXX",
-      quantity: 1,
-    },
-    {
-      id: "yWEpMImZRg",
-      type: "sku_list_items",
-      sku_code: "TSHIRTMM000000FFFFF222",
-      quantity: 5,
-    },
-  ],
-} as unknown as SkuList
+} as SkuList
+const skuListWithManualItems = [
+  {
+    id: "rzDpOINGZz",
+    type: "sku_list_items",
+    sku_code: "TSHIRTMS000000FFFFFFLXXX",
+    quantity: 2,
+  },
+  {
+    id: "MgMRPIKVqW",
+    type: "sku_list_items",
+    sku_code: "TSHIRTMM000000FFFFFFXLXX",
+    quantity: 1,
+  },
+  {
+    id: "yWEpMImZRg",
+    type: "sku_list_items",
+    sku_code: "TSHIRTMM000000FFFFF222",
+    quantity: 5,
+  },
+] as SkuListItem[]
+const skuListWithManualSkus = [
+  {
+    code: "TSHIRTMS000000FFFFFFLXXX",
+  },
+  { code: "TSHIRTMM000000FFFFFFXLXX" },
+  { code: "TSHIRTMM000000FFFFF222" },
+] as Sku[]
 
 describe("normalizeSkusInList", () => {
   test("should return a simple array of type SkuWithQuantity when manual is false", () => {
-    const skus = normalizeSkusInList(skuListWithRegex)
+    const skus = normalizeSkusInList(
+      skuListWithRegex,
+      skuListWithRegexItems,
+      skuListWithRegexSkus
+    )
     expect(skus).toStrictEqual([
       {
         sku: {
@@ -108,7 +112,11 @@ describe("normalizeSkusInList", () => {
   })
 
   test("should return a simple array of type SkuWithQuantity when manual is true", () => {
-    const skus = normalizeSkusInList(skuListWithManual)
+    const skus = normalizeSkusInList(
+      skuListWithManual,
+      skuListWithManualItems,
+      skuListWithManualSkus
+    )
 
     expect(skus).toStrictEqual([
       {

--- a/packages/microstore/src/providers/SkuListProvider/normalizeSkusInList.ts
+++ b/packages/microstore/src/providers/SkuListProvider/normalizeSkusInList.ts
@@ -1,4 +1,4 @@
-import { SkuList } from "@commercelayer/sdk"
+import { Sku, SkuList, SkuListItem } from "@commercelayer/sdk"
 
 import { SkuWithPrices } from "."
 
@@ -11,16 +11,20 @@ import { SkuWithQuantity } from "@typings/urlData"
  *
  * @param skuList - The fetched sku_list resource object returned from SDK
  */
-export const normalizeSkusInList = (skuList: SkuList): SkuWithQuantity[] => {
+export const normalizeSkusInList = (
+  skuList: SkuList,
+  skuListItems: SkuListItem[],
+  skus: Sku[]
+): SkuWithQuantity[] => {
   return skuList.manual
-    ? (skuList.sku_list_items || []).map((item) => {
-        const sku = skuList.skus?.find((sku) => sku.code === item.sku_code)
+    ? (skuListItems || []).map((item) => {
+        const sku = skus?.find((sku) => sku.code === item.sku_code)
         return {
           quantity: item.quantity || 1,
           sku: sku as SkuWithPrices,
         }
       })
-    : (skuList.skus || []).map((item) => ({
+    : (skus || []).map((item) => ({
         quantity: 1,
         sku: item as SkuWithPrices,
       }))

--- a/packages/microstore/src/utils/removeAllLineItems.ts
+++ b/packages/microstore/src/utils/removeAllLineItems.ts
@@ -7,10 +7,7 @@ export const removeAllLineItems = async ({
   client: CommerceLayerClient
   orderId: string
 }) => {
-  const { line_items: lineItems } = await client.orders.retrieve(orderId, {
-    fields: ["line_items"],
-    include: ["line_items"],
-  })
+  const lineItems = await client.orders.line_items(orderId)
   if (lineItems && lineItems?.length > 0) {
     await Promise.all(
       lineItems.map(async (lineItem) => {


### PR DESCRIPTION
Closes @commercelayer/issues-app#97

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- I refactorized the `SkuListProvider` and some other helpers to avoid the usage of `include` of `has_many` relationships according to new internal policies
- I fixed the sorting of `sku_list_items` to sort them by `position` ascending

### Notes
Having splitted the included relationships into separate requests could lead into pagination issues. At the moment I did not managed any pagination for `sku_list_items` because they seem to be limited to `12` by business logic. Instead I paginated the results of `skus` and `prices`. Eventually we could set a custom maximum amount of pages that we want to fetch.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
