### PR TITLE
Propagate link id to order if present

### DIFF
--- a/packages/microstore/@typings/urlData.d.ts
+++ b/packages/microstore/@typings/urlData.d.ts
@@ -14,4 +14,5 @@ type UrlData = {
   inline?: boolean
   lang?: string
   all?: boolean // buy all
+  linkId?: string
 }

--- a/packages/microstore/specs/e2e/link-id.spec.ts
+++ b/packages/microstore/specs/e2e/link-id.spec.ts
@@ -1,0 +1,79 @@
+import { authenticate } from "@commercelayer/js-auth"
+import { test, expect } from "@playwright/test"
+
+import { MicrostorePage } from "../fixtures/MicrostorePage"
+
+const getToken = async () => {
+  const data = await authenticate("client_credentials", {
+    clientId: process.env.E2E_CLIENT_ID as string,
+    scope: process.env.E2E_MARKET_ID as string,
+  })
+  return data?.accessToken as string
+}
+
+const captureOrderRequests = async (
+  page: ConstructorParameters<typeof MicrostorePage>[0]
+) => {
+  const captured: Array<{ method: string; body: ReturnType<Request["json"]> }> =
+    []
+  await page.route("**/api/orders/**", async (route, request) => {
+    if (["POST", "PATCH"].includes(request.method())) {
+      captured.push({
+        method: request.method(),
+        body: request.postDataJSON(),
+      })
+    }
+    await route.continue()
+  })
+  return captured
+}
+
+test.describe("linkId URL param is propagated to the order metadata", () => {
+  test("should set linkId in order metadata on page load (cart inline mode)", async ({
+    page,
+  }) => {
+    const microstorePage = new MicrostorePage(page)
+    const capturedRequests = await captureOrderRequests(page)
+
+    const accessToken = await getToken()
+    await microstorePage.goto({
+      accessToken,
+      skuListId: process.env.E2E_SKU_LIST_ID,
+      cart: true,
+      inline: true,
+      linkId: "test-link-id-cart",
+    })
+
+    const hasLinkId = capturedRequests.some(
+      (req) =>
+        (req.body as any)?.data?.attributes?.metadata?.links_api?.link_id ===
+        "test-link-id-cart"
+    )
+    expect(hasLinkId).toBe(true)
+  })
+
+  test("should set linkId in order metadata when using buy all", async ({
+    page,
+  }) => {
+    const microstorePage = new MicrostorePage(page)
+    const capturedRequests = await captureOrderRequests(page)
+
+    const accessToken = await getToken()
+    await microstorePage.goto({
+      accessToken,
+      skuListId: process.env.E2E_SKU_LIST_ID,
+      all: true,
+      linkId: "test-link-id-buyall",
+    })
+
+    await microstorePage.buyAllButton.click()
+    await page.waitForLoadState("networkidle")
+
+    const hasLinkId = capturedRequests.some(
+      (req) =>
+        (req.body as any)?.data?.attributes?.metadata?.links_api?.link_id ===
+        "test-link-id-buyall"
+    )
+    expect(hasLinkId).toBe(true)
+  })
+})

--- a/packages/microstore/specs/fixtures/MicrostorePage.ts
+++ b/packages/microstore/specs/fixtures/MicrostorePage.ts
@@ -4,6 +4,9 @@ interface GoToProps {
   accessToken?: string
   cart?: boolean
   skuListId?: string
+  all?: boolean
+  inline?: boolean
+  linkId?: string
 }
 
 interface AttributesProps {

--- a/packages/microstore/specs/fixtures/tokenizedPage.ts
+++ b/packages/microstore/specs/fixtures/tokenizedPage.ts
@@ -10,6 +10,7 @@ export interface DefaultParamsProps {
   cart?: boolean
   inline?: boolean
   all?: boolean
+  linkId?: string
 }
 
 type FixtureType = {

--- a/packages/microstore/src/components/composite/MicrostoreContainer/index.tsx
+++ b/packages/microstore/src/components/composite/MicrostoreContainer/index.tsx
@@ -25,7 +25,7 @@ function MicrostoreContainer({
   couponCode,
   children,
 }: Props): JSX.Element {
-  const { cart, lang, inline } = useDataFromUrl()
+  const { cart, lang, inline, linkId } = useDataFromUrl()
   const { i18n } = useTranslation()
 
   useEffect(() => {
@@ -46,6 +46,9 @@ function MicrostoreContainer({
             language_code: lang,
             coupon_code: couponCode,
             return_url: returnUrl,
+            ...(linkId != null && {
+              metadata: { links_api: { link_id: linkId } },
+            }),
           }}
         >
           <Base>

--- a/packages/microstore/src/hooks/useDataFromUrl.ts
+++ b/packages/microstore/src/hooks/useDataFromUrl.ts
@@ -15,6 +15,7 @@ export const useDataFromUrl = () => {
       const inline = search.get("inline") || "true"
       const all = search.get("all") || undefined
       const lang = search.get("lang") || "en"
+      const linkId = search.get("linkId") || undefined
 
       setData({
         description: parseQueryValue(description),
@@ -25,6 +26,7 @@ export const useDataFromUrl = () => {
         inline: parseBooleanValue(inline),
         all: parseBooleanValue(all),
         lang: parseQueryValue(lang),
+        linkId: parseQueryValue(linkId),
       })
     }
   }, [])

--- a/packages/microstore/src/providers/BuyAllProvider/index.tsx
+++ b/packages/microstore/src/providers/BuyAllProvider/index.tsx
@@ -39,7 +39,7 @@ export const BuyAllProvider: FC<BuyAllProviderProps> = ({
   settings,
   skus,
 }) => {
-  const { all, cart } = useDataFromUrl()
+  const { all, cart, linkId } = useDataFromUrl()
   const [internalSkus, setInternalSkus] = useState<SkuWithQuantity[]>([])
   const [isBuyingAll, setIsBuyingAll] = useState(false)
   const [showBuyAllButton, setShowBuyAllButton] = useState(false)
@@ -62,6 +62,7 @@ export const BuyAllProvider: FC<BuyAllProviderProps> = ({
         accessToken: settings.accessToken,
         domain: settings.domain,
         slug: settings.slug,
+        linkId,
       })
 
       if (!order) {

--- a/packages/microstore/src/utils/buyAllSkus.ts
+++ b/packages/microstore/src/utils/buyAllSkus.ts
@@ -10,11 +10,13 @@ export const buyAllSkus = async ({
   accessToken,
   slug,
   domain,
+  linkId,
 }: {
   skus: SkuWithQuantity[]
   accessToken: string
   slug: string
   domain: string
+  linkId?: string
 }) => {
   const client = CommerceLayer({
     organization: slug,
@@ -24,7 +26,7 @@ export const buyAllSkus = async ({
 
   const orderId = await getOrCreateOrderId(client, slug)
 
-  await updateOrderAttributes({ client, orderId, autorefresh: false })
+  await updateOrderAttributes({ client, orderId, autorefresh: false, linkId })
   await removeAllLineItems({ client, orderId })
   await createLineItems({ client, skus, orderId })
   const updatedOrder = await updateOrderAttributes({

--- a/packages/microstore/src/utils/updateOrderAttributes.ts
+++ b/packages/microstore/src/utils/updateOrderAttributes.ts
@@ -5,15 +5,20 @@ export const updateOrderAttributes = async ({
   orderId,
   autorefresh,
   returnUrl,
+  linkId,
 }: {
   client: CommerceLayerClient
   orderId: string
   autorefresh: boolean
   returnUrl?: string
+  linkId?: string
 }) => {
   return await client.orders.update({
     id: orderId,
     autorefresh,
     return_url: returnUrl,
+    ...(linkId != null && {
+      metadata: { links_api: { link_id: linkId } },
+    }),
   })
 }


### PR DESCRIPTION
Closes #108 

## What I did

This pull request introduces support for propagating a `linkId` URL parameter through the microstore flow, ensuring it is set in the order metadata for both cart inline mode and "buy all" actions. The changes span the e2e test suite, core React components, hooks, and utility functions, enabling end-to-end testing and correct metadata assignment.

**End-to-end test enhancements:**

- Added new e2e tests in `link-id.spec.ts` to verify that the `linkId` URL parameter is correctly propagated to the order metadata for both cart inline mode and "buy all" actions.

**Core logic and data flow:**

- Updated the `useDataFromUrl` hook and related type definitions to extract `linkId` from the URL and make it available throughout the application. [[1]](diffhunk://#diff-e7d9c2e85f757631915bc1a6b78d9a0eab9b8f43eed19222e4f7473819c85203R18) [[2]](diffhunk://#diff-e7d9c2e85f757631915bc1a6b78d9a0eab9b8f43eed19222e4f7473819c85203R29) [[3]](diffhunk://#diff-07c1599b3681c9dff78828c50cf28c769b3d7da6c7d6676a71a5d3aaaaa7c7dbR7-R9) [[4]](diffhunk://#diff-f6c0299553d564f9273b0cd9149398a6d2012abdbbba65a362ef9dfc563cdaacR13)
- Modified `MicrostoreContainer` and `BuyAllProvider` components to retrieve and pass the `linkId` value when creating or updating orders. [[1]](diffhunk://#diff-94e49aece853d25f79e6c73dd3f5b6f42056e035707c66d88aa31b7c4076039dL28-R28) [[2]](diffhunk://#diff-94e49aece853d25f79e6c73dd3f5b6f42056e035707c66d88aa31b7c4076039dR49-R51) [[3]](diffhunk://#diff-4958fc17c21f25d9c0ea6ca9fcd167c93a8356decc91002b13347e91ae9ab736L42-R42) [[4]](diffhunk://#diff-4958fc17c21f25d9c0ea6ca9fcd167c93a8356decc91002b13347e91ae9ab736R65)

**Order utilities:**

- Updated `buyAllSkus` and `updateOrderAttributes` utility functions to accept and propagate the `linkId` parameter, ensuring it is included in the order's metadata. [[1]](diffhunk://#diff-83b6e411ac0fc522b2f0a85f40cc67171775e57e8a4d007478c7bf1e0733e084R13-R19) [[2]](diffhunk://#diff-83b6e411ac0fc522b2f0a85f40cc67171775e57e8a4d007478c7bf1e0733e084L27-R29) [[3]](diffhunk://#diff-9a5c213c3acb91ce0c8fa6ac69132eb0b474a7a21ad190b5c3d9841d62d4cd0eR8-R22)

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
